### PR TITLE
Prevent launching instance on init failure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "disabled"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "disabled"
+}

--- a/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java
@@ -253,11 +253,28 @@ public class EC2UnixLauncher extends EC2ComputerLauncher {
 
                         logInfo(computer, listener, "Executing init script");
                         String initCommand = buildUpCommand(computer, tmpDir + "/init.sh");
-                        executeRemote(clientSession, initCommand, logger);
-
-                        logInfo(computer, listener, "Creating ~/.hudson-run-init");
-                        String createHudsonRunInitCommand = buildUpCommand(computer, "touch ~/.hudson-run-init");
-                        executeRemote(clientSession, createHudsonRunInitCommand, logger);
+                        // Set the flag only when init script executed successfully.
+                        if (executeRemote(clientSession, initCommand, logger)) {
+                            log(
+                                    Level.FINE,
+                                    computer,
+                                    listener,
+                                    "Init script executed successfully and creating ~/.hudson-run-init");
+                            String createHudsonRunInitCommand = buildUpCommand(computer, "touch ~/.hudson-run-init");
+                            if (!executeRemote(clientSession, createHudsonRunInitCommand, logger)) {
+                                logInfo(computer, listener, "Unable to create ~/.hudson-run-init");
+                            }
+                        } else {
+                            log(
+                                    Level.WARNING,
+                                    computer,
+                                    listener,
+                                    "Failed to execute init script on " + node.getInstanceId());
+                            clientSession.close();
+                            scp.close();
+                            client.stop();
+                            throw new IOException("Failed to execute init script on " + node.getInstanceId());
+                        }
                     }
 
                     executeRemote(

--- a/src/test/java/hudson/plugins/ec2/ssh/InitScriptExecutionTest.java
+++ b/src/test/java/hudson/plugins/ec2/ssh/InitScriptExecutionTest.java
@@ -1,0 +1,273 @@
+package hudson.plugins.ec2.ssh;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import hudson.model.TaskListener;
+import hudson.plugins.ec2.ConnectionStrategy;
+import hudson.plugins.ec2.EC2AbstractSlave;
+import hudson.plugins.ec2.EC2Cloud;
+import hudson.plugins.ec2.EC2Computer;
+import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.util.KeyHelper;
+import hudson.plugins.ec2.util.KeyPair;
+import hudson.plugins.ec2.util.SSHClientHelper;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.channel.ChannelExec;
+import org.apache.sshd.client.future.AuthFuture;
+import org.apache.sshd.client.future.ConnectFuture;
+import org.apache.sshd.client.future.OpenFuture;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.scp.client.CloseableScpClient;
+import org.apache.sshd.scp.client.ScpClient;
+import org.apache.sshd.scp.client.ScpClientCreator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.mockito.MockedStatic;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.KeyPairInfo;
+
+public class InitScriptExecutionTest {
+    private EC2Computer mockEC2Computer;
+    private TaskListener mockListener;
+    private PrintStream mockPS;
+    private PrintWriter mockPW;
+    private EC2AbstractSlave mockNode;
+    private SlaveTemplate mockTemplate;
+    private EC2Cloud mockCloud;
+    private KeyPair mockKp;
+    private KeyPairInfo mockKPInfo;
+    private Instance mockInstance;
+    private MockedStatic<SSHClientHelper> mockStaticSSHClientHelper;
+    private MockedStatic<KeyHelper> mockStaticKeyHelper;
+    private SSHClientHelper mockSSHClientHelper;
+    private ClientSession mockClientSession;
+    private SshClient mockSshClient;
+    private ScpClient mockScpClient;
+    private MockedStatic<CloseableScpClient> mockStaticClosableScpClient;
+    private CloseableScpClient mockClosableScpClient;
+    private MockedStatic<ScpClientCreator> mockStaticScpClientCreator;
+    private ScpClientCreator mockScpClientCreator;
+    private ConnectFuture mockConnectFuture;
+    private AuthFuture mockAuthFuture;
+    private java.security.KeyPair mockKeyPair;
+    private ChannelExec mockAgentChannelExec;
+    private OpenFuture mockOpenFuture;
+    private final String mockAdmin = "jenkinsAdmin";
+    private final String mockHost = "example.com";
+    private EC2UnixLauncher launcher;
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Rule
+    public LoggerRule loggerRule = new LoggerRule();
+
+    private EC2AbstractSlave getMockNodeTemplate(String initScript) throws Exception {
+        return new EC2AbstractSlave(
+                "InitScriptTestInstance",
+                "i-initscripttest",
+                "description",
+                "fs",
+                1,
+                null,
+                "label",
+                null,
+                null,
+                initScript,
+                "/tmp",
+                new ArrayList<>(),
+                "remote",
+                EC2AbstractSlave.DEFAULT_JAVA_PATH,
+                "jvm",
+                false,
+                "idle",
+                null,
+                "cloud",
+                Integer.MAX_VALUE,
+                null,
+                null,
+                -1,
+                null,
+                EC2AbstractSlave.DEFAULT_METADATA_ENDPOINT_ENABLED,
+                EC2AbstractSlave.DEFAULT_METADATA_TOKENS_REQUIRED,
+                EC2AbstractSlave.DEFAULT_METADATA_HOPS_LIMIT,
+                EC2AbstractSlave.DEFAULT_METADATA_SUPPORTED) {
+            @Override
+            public void terminate() {}
+
+            @Override
+            public String getEc2Type() {
+                return null;
+            }
+        };
+    }
+
+    private void defineBehaviourCommon() throws Exception, IOException {
+        // Define the mock behaviour.
+        when(mockListener.getLogger()).thenReturn(mockPS);
+        when(mockListener.error(any())).thenReturn(mockPW);
+        when(mockEC2Computer.getNode()).thenReturn(mockNode);
+        when(mockEC2Computer.getSlaveTemplate()).thenReturn(mockTemplate);
+        mockStaticSSHClientHelper.when(() -> SSHClientHelper.getInstance()).thenReturn(mockSSHClientHelper);
+        when(mockSSHClientHelper.setupSshClient(any())).thenReturn(mockSshClient);
+        when(mockEC2Computer.getCloud()).thenReturn(mockCloud);
+        when(mockCloud.getKeyPair()).thenReturn(mockKp);
+        when(mockKp.getKeyPairInfo()).thenReturn(mockKPInfo);
+        when(mockKPInfo.keyName()).thenReturn("initscripttest_keyname");
+        when(mockKPInfo.keyFingerprint()).thenReturn("initscripttest_fingerprint");
+        mockTemplate.connectionStrategy = ConnectionStrategy.PUBLIC_DNS;
+        when(mockEC2Computer.updateInstanceDescription()).thenReturn(mockInstance);
+        when(mockInstance.publicDnsName()).thenReturn(mockHost);
+        mockStaticScpClientCreator.when(() -> ScpClientCreator.instance()).thenReturn(mockScpClientCreator);
+        when(mockScpClientCreator.createScpClient(mockClientSession)).thenReturn(mockScpClient);
+        mockStaticScpClientCreator
+                .when(() -> CloseableScpClient.singleSessionInstance(mockScpClient))
+                .thenReturn(mockClosableScpClient);
+        doNothing().when(mockSshClient).setServerKeyVerifier(any());
+        doNothing().when(mockSshClient).start();
+        doNothing().when(mockSshClient).setClientProxyConnector(any());
+        when(mockEC2Computer.getRemoteAdmin()).thenReturn(mockAdmin);
+        when(mockSshClient.connect(mockAdmin, mockHost, 0)).thenReturn(mockConnectFuture);
+        when(mockConnectFuture.verify(10000, TimeUnit.SECONDS)).thenReturn(mockConnectFuture);
+        when(mockConnectFuture.getClientSession()).thenReturn(mockClientSession);
+        when(mockKp.getMaterial()).thenReturn("initscripttest_keymaterial");
+        mockStaticKeyHelper
+                .when(() -> KeyHelper.decodeKeyPair("initscripttest_keymaterial", ""))
+                .thenReturn(mockKeyPair);
+        doNothing().when(mockClientSession).addPublicKeyIdentity(mockKeyPair);
+        when(mockClientSession.auth()).thenReturn(mockAuthFuture);
+        when(mockAuthFuture.await()).thenReturn(true);
+        when(mockClientSession.isAuthenticated()).thenReturn(true);
+        when(mockClientSession.createExecChannel(any(), any(), any(), any())).thenReturn(mockAgentChannelExec);
+        when(mockAgentChannelExec.open()).thenReturn(mockOpenFuture);
+        when(mockOpenFuture.verify(10000)).thenReturn(mockOpenFuture);
+        String tmpDirCmd = "mkdir -p /tmp";
+        doNothing().when(mockClientSession).executeRemoteCommand(tmpDirCmd, mockPS, mockPS, null);
+        String markerChkCmd = "test -e ~/.hudson-run-init";
+        doThrow(new IOException("Marker doesn't exists"))
+                .when(mockClientSession)
+                .executeRemoteCommand(markerChkCmd, mockPS, mockPS, null);
+        doNothing().when(mockScpClient).upload(any(), any(), any(), any());
+    }
+
+    @Before
+    public void setUp() throws Exception, IOException {
+        // Set up the test environment
+        mockEC2Computer = mock(EC2Computer.class);
+        mockListener = mock(TaskListener.class);
+        mockPS = mock(PrintStream.class);
+        mockPW = new PrintWriter(System.out);
+        mockTemplate = mock(SlaveTemplate.class);
+        mockCloud = mock(EC2Cloud.class);
+        mockKp = mock(KeyPair.class);
+        mockKPInfo = mock(KeyPairInfo.class);
+        mockInstance = mock(Instance.class);
+        mockStaticSSHClientHelper = mockStatic(SSHClientHelper.class);
+        mockStaticKeyHelper = mockStatic(KeyHelper.class);
+        mockSSHClientHelper = mock(SSHClientHelper.class);
+        mockClientSession = mock(ClientSession.class);
+        mockSshClient = mock(SshClient.class);
+        mockScpClient = mock(ScpClient.class);
+        mockStaticClosableScpClient = mockStatic(CloseableScpClient.class);
+        mockClosableScpClient = mock(CloseableScpClient.class);
+        mockStaticScpClientCreator = mockStatic(ScpClientCreator.class);
+        mockScpClientCreator = mock(ScpClientCreator.class);
+        mockConnectFuture = mock(ConnectFuture.class);
+        mockAuthFuture = mock(AuthFuture.class);
+        mockKeyPair = mock(java.security.KeyPair.class);
+        mockAgentChannelExec = mock(ChannelExec.class);
+        mockOpenFuture = mock(OpenFuture.class);
+    }
+
+    @Test
+    public void testInitScriptExecutionSuccessful() throws Exception, IOException {
+        String initScript = "echo 'Hello World'";
+        mockNode = getMockNodeTemplate(initScript);
+        launcher = spy(new EC2UnixLauncher());
+
+        // Define behaviour.
+        defineBehaviourCommon();
+        doReturn(initScript).when(launcher).buildUpCommand(mockEC2Computer, "/tmp/init.sh");
+        doNothing().when(mockClientSession).executeRemoteCommand(initScript, mockPS, mockPS, null);
+        doReturn("touch ~/.hudson-run-init").when(launcher).buildUpCommand(mockEC2Computer, "touch ~/.hudson-run-init");
+        doNothing().when(mockClientSession).executeRemoteCommand("touch ~/.hudson-run-init", mockPS, mockPS, null);
+
+        // Execute test.
+        loggerRule.capture(3).record("hudson.plugins.ec2.ssh.EC2UnixLauncher", Level.ALL);
+        launcher.launch(mockEC2Computer, mockListener);
+        // Test for marker doesn't exists.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message -> message.contains("Failed to execute remote command: test -e ~/.hudson-run-init")));
+        // Test for successful init script execution.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message ->
+                        message.contains("Init script executed successfully and creating ~/.hudson-run-init")));
+    }
+
+    @Test
+    public void testInitScriptExecutionFailure() throws Exception, IOException {
+        String initScript = "exit 1";
+        mockNode = getMockNodeTemplate(initScript);
+        launcher = spy(new EC2UnixLauncher());
+
+        // Define behaviour.
+        defineBehaviourCommon();
+        doReturn(initScript).when(launcher).buildUpCommand(mockEC2Computer, "/tmp/init.sh");
+        doThrow(new IOException("Command failed"))
+                .when(mockClientSession)
+                .executeRemoteCommand(initScript, mockPS, mockPS, null);
+
+        // Execute test.
+        loggerRule.capture(5).record("hudson.plugins.ec2.ssh.EC2UnixLauncher", Level.ALL);
+        launcher.launch(mockEC2Computer, mockListener);
+        // Test for marker doesn't exists.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message -> message.contains("Failed to execute remote command: test -e ~/.hudson-run-init")));
+        // Test for failed init script execution.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message -> message.contains("Failed to execute remote command: exit 1")));
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message -> message.contains("Failed to execute init script on i-initscripttest")));
+    }
+
+    @Test
+    public void testInitScriptExecutionSuccessfulButMarkerCreationFailure() throws Exception, IOException {
+        String initScript = "echo 'Hello World'";
+        mockNode = getMockNodeTemplate(initScript);
+        launcher = spy(new EC2UnixLauncher());
+
+        // Define behaviour.
+        defineBehaviourCommon();
+        doReturn(initScript).when(launcher).buildUpCommand(mockEC2Computer, "/tmp/init.sh");
+        doNothing().when(mockClientSession).executeRemoteCommand(initScript, mockPS, mockPS, null);
+        doReturn("touch ~/.hudson-run-init").when(launcher).buildUpCommand(mockEC2Computer, "touch ~/.hudson-run-init");
+        doThrow(new IOException("Command failed"))
+                .when(mockClientSession)
+                .executeRemoteCommand("touch ~/.hudson-run-init", mockPS, mockPS, null);
+
+        // Execute test.
+        loggerRule.capture(5).record("hudson.plugins.ec2.ssh.EC2UnixLauncher", Level.ALL);
+        launcher.launch(mockEC2Computer, mockListener);
+        // Test for marker doesn't exists.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message -> message.contains("Failed to execute remote command: test -e ~/.hudson-run-init")));
+        // Test for successful init script execution.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message ->
+                        message.contains("Init script executed successfully and creating ~/.hudson-run-init")));
+        // Test for failed marker creation.
+        assertTrue(loggerRule.getMessages().stream()
+                .anyMatch(message -> message.contains("Unable to create ~/.hudson-run-init")));
+    }
+}


### PR DESCRIPTION
## Description
This PR attempts to do proper error handling around execution of init script, so that the plugin can prevent launching of a faulty EC2 agent.

## Why is this change needed?
We need this change because init script is used to prepare the EC2 agent with some pre-requisites with all necessary dependencies to execute a Jenkins job. If init script fails to execute successfully it implies all dependencies haven't been satisfied, in such case the EC2 agent even if it is launched will be a faulty one as it will be unable to successfully execute the jobs. So in case if the init script fails then the EC2 agent should also be prevented from getting launched and should be terminated.

## Tests
### Unit Tests
Have added units tests  for verifying init script execution. Screenshots below:
<img width="1244" alt="UT Execution Log" src="https://github.com/user-attachments/assets/fc6ba8b9-f6a9-473c-b061-2ba94b3fa5bd" />



### Manual Tests
#### Scenario 1 - init script with forced exception having explicit `exit 1`
<img width="1337" alt="Init Script Error1" src="https://github.com/user-attachments/assets/6084f0a0-21fe-4b7d-b8e8-8bdf6b246ea2" />
<img width="1563" alt="Init Script Error2" src="https://github.com/user-attachments/assets/643448f1-5fc2-4ed7-b432-b0697211ba8a" />

#### Scenario 2 - init script without forced exception
<img width="1323" alt="Good Init Script 1" src="https://github.com/user-attachments/assets/ad19d66d-49bf-4ebd-a4a4-ebce821fd9ae" />
<img width="1317" alt="Good Init Script 2" src="https://github.com/user-attachments/assets/2587937d-a455-4c69-a4d9-a669ed2354c4" />
<img width="1321" alt="Good Init Script 3" src="https://github.com/user-attachments/assets/0f937469-91f0-44e9-827b-5fbfce713006" />
